### PR TITLE
Puppet5

### DIFF
--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -190,12 +190,24 @@ define stunnel::tun (
       $service_require = File[$initscript_file]
       $service_before = undef
     }
-    service { "stunnel-${name}":
-      ensure    => $service_ensure_real,
-      enable    => $service_enable,
-      require   => $service_require,
-      before    => $service_before,
-      subscribe => File[$config_file],
+
+    if versioncmp('4.0', $::puppetversion) > 0 {
+      service { "stunnel-${name}":
+        ensure    => $service_ensure_real,
+        enable    => $service_enable,
+        provider  => $service_init_system_real,
+        require   => $service_require,
+        before    => $service_before,
+        subscribe => File[$config_file],
+      }
+    } else {
+      service { "stunnel-${name}":
+        ensure    => $service_ensure_real,
+        enable    => $service_enable,
+        require   => $service_require,
+        before    => $service_before,
+        subscribe => File[$config_file],
+      }
     }
   }
 }

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -193,7 +193,6 @@ define stunnel::tun (
     service { "stunnel-${name}":
       ensure    => $service_ensure_real,
       enable    => $service_enable,
-      provider  => $service_init_system_real,
       require   => $service_require,
       before    => $service_before,
       subscribe => File[$config_file],


### PR DESCRIPTION
hard coding provider on puppet versions > 4 leads to unexpected on systems which use init, i have seen reference to support for this provider being dropped, this fix maintains previous behaviour on systems pre puppet 4.