### PR TITLE
CVF-6820: Allow overriding stunnel package version

### DIFF
--- a/manifests/data.pp
+++ b/manifests/data.pp
@@ -5,7 +5,7 @@
 class stunnel::data {
   case $::osfamily {
     /RedHat/: {
-      $package = [ 'stunnel', 'redhat-lsb' ]
+      $package = { 'stunnel' => { ensure => $stunnel::ensure }, 'redhat-lsb' => {} }
       $service = 'stunnel'
       $bin_name = 'stunnel'
       $bin_path = '/usr/bin'
@@ -24,7 +24,7 @@ class stunnel::data {
       }
     }
     /Debian/: {
-      $package = [ 'stunnel4', 'lsb-base' ]
+      $package = { 'stunnel4' => { ensure => $stunnel::ensure }, 'lsb-base' => {} }
       $service = 'stunnel'
       $bin_name = 'stunnel4'
       $bin_path = '/usr/bin'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,9 @@
 #
 # STunnel Management
 #
-class stunnel {
+class stunnel (
+  Optional[String] $ensure = installed,
+) {
   file { '/usr/local/bin/stunnel-combine-certs':
     ensure => 'present',
     owner  => 'root',


### PR DESCRIPTION
On Ubuntu 18.04 we need to ensure we have the `latest` stunnel4 package version.